### PR TITLE
JSON.parse error fix on nebulas network error

### DIFF
--- a/lib/httprequest.js
+++ b/lib/httprequest.js
@@ -5,59 +5,66 @@ var axios = require("axios");
 var debugLog = false;
 
 var HttpRequest = function (host, timeout, apiVersion) {
-    this.host = host || "http://localhost:8685";
-    this.timeout = timeout || 0;
-    this.apiVersion = apiVersion || "v1";
+	this.host = host || "http://localhost:8685";
+	this.timeout = timeout || 0;
+	this.apiVersion = apiVersion || "v1";
 };
 
 HttpRequest.prototype.setHost = function (host) {
-    this.host = host;
+	this.host = host;
 };
 
 HttpRequest.prototype.setAPIVersion = function (apiVersion) {
-    this.apiVersion = apiVersion;
+	this.apiVersion = apiVersion;
 };
 
 HttpRequest.prototype.createUrl = function (api) {
-    return this.host + "/" + this.apiVersion + api;
+	return this.host + "/" + this.apiVersion + api;
 };
 
 HttpRequest.prototype.request = function (method, api, payload, axiosOptions) {
-    if (debugLog) {
-        console.log("[debug] HttpRequest: " + method + " " + this.createUrl(api) + " " + JSON.stringify(payload));
-    }
+	if (debugLog) {
+		console.log("[debug] HttpRequest: " + method + " " + this.createUrl(api) + " " + JSON.stringify(payload));
+	}
 
-    var axiosParams = {
-        method: method,
-        url: this.createUrl(api),
-        data: payload,
-        transformResponse: [function (resp) {
-            if (typeof (resp) === "string") {
-                resp = JSON.parse(resp);
-            }
-            return resp.result || resp;
-        }]
-    };
-    if (axiosOptions && typeof axiosOptions.onDownloadProgress === 'function') {
-        axiosParams.onDownloadProgress = axiosOptions.onDownloadProgress;
-    }
-    return axios(axiosParams).then(function (resp) {
-        return resp.data;
-    }).catch(function (e) {
-        if (typeof e.response !== "undefined") {
-            throw new Error(e.response.data.error);
-        } else {
-            throw new Error(e.message);
-        }
-    });
+	var axiosParams = {
+		method: method,
+		url: this.createUrl(api),
+		data: payload,
+	};
+	if (axiosOptions && typeof axiosOptions.onDownloadProgress === 'function') {
+		axiosParams.onDownloadProgress = axiosOptions.onDownloadProgress;
+	}
+	return axios(axiosParams).then(function (resp) {
+		if("text/html; charset=UTF-8"==resp.headers['content-type']){
+			throw new Error(resp.status+' - '+resp.statusText);
+		}
+		if(typeof(resp.data)=="string"){
+			try{
+				resp.data=JSON.parse(resp.data);
+			} catch(e){
+				throw new Error('Response is invalid json');
+			}
+		}
+		return resp.data.result || resp.data;
+	}).catch(function (e) {
+		if (typeof e.response !== "undefined") {
+			var err=typeof(e.response.data) == 'object' ? e.response.data.error || e.response.data.err : e.response.status+' - '+e.response.statusText;
+			err+="\n"+api + " " + JSON.stringify(payload);
+			throw new Error(err);
+			
+		} else {
+			throw new Error(e.message);
+		}
+	});
 };
 
 HttpRequest.prototype.asyncRequest = function (method, api, payload, callback) {
-    return this.request(method, api, payload).then(function (data) {
-        callback(data);
-    }).catch(function (err) {
-        callback(err);
-    });
+	return this.request(method, api, payload).then(function (data) {
+		callback(data);
+	}).catch(function (err) {
+		callback(err);
+	});
 };
 
 module.exports = HttpRequest;


### PR DESCRIPTION
When mainnet or testnet gave error or became unreachable cloudflare returns html error pages for 502, 522 http error codes. 

ResponseTransform of axios cant handle that and only show unable to parse json errror. Instead of this code can show which request get error and what kind of error happened.

I change httprequest.js and add some control over axios thenable.